### PR TITLE
Update docker-compose.yaml to fix the issue that is reported for dockerised-quickstart tutorial

### DIFF
--- a/kafka-integration/dockerized-quickstart/docker-compose.yaml
+++ b/kafka-integration/dockerized-quickstart/docker-compose.yaml
@@ -49,5 +49,5 @@ services:
       - kafka
     environment:
       - KAFKA_BOOTSTRAP_SERVER=kafka:9092
-      - KAFKA_TOPIC=multijson-events
+      - KAFKA_TOPIC=storm-events
       - SOURCE_FILE=StormEvents.csv


### PR DESCRIPTION
The dockerised-quickstart part of the tutorial is not updating the data in Azure tables (the connector and producer is working fine).
There is a mismatch in the topic name between the producer and connector and upon making this change it started working